### PR TITLE
Add context to server handler interfaces

### DIFF
--- a/acceptfunc_test.go
+++ b/acceptfunc_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"testing"
 )
 
@@ -28,7 +29,7 @@ func TestAcceptNotify(t *testing.T) {
 	}
 }
 
-func handleNotify(w ResponseWriter, req *Msg) {
+func handleNotify(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	w.WriteMsg(m)

--- a/client_test.go
+++ b/client_test.go
@@ -342,7 +342,7 @@ func TestClientEDNS0Local(t *testing.T) {
 	optStr1 := "1979:0x0707"
 	optStr2 := strconv.Itoa(EDNS0LOCALSTART) + ":0x0601"
 
-	handler := func(w ResponseWriter, req *Msg) {
+	handler := func(ctx context.Context, w ResponseWriter, req *Msg) {
 		m := new(Msg)
 		m.SetReply(req)
 
@@ -667,7 +667,7 @@ func TestConcurrentExchanges(t *testing.T) {
 
 	for _, m := range cases {
 		mm := m // redeclare m so as not to trip the race detector
-		handler := func(w ResponseWriter, req *Msg) {
+		handler := func(ctx context.Context, w ResponseWriter, req *Msg) {
 			r := mm.Copy()
 			r.SetReply(req)
 

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"sync"
 )
 
@@ -70,7 +71,7 @@ func (mux *ServeMux) Handle(pattern string, handler Handler) {
 }
 
 // HandleFunc adds a handler function to the ServeMux for pattern.
-func (mux *ServeMux) HandleFunc(pattern string, handler func(ResponseWriter, *Msg)) {
+func (mux *ServeMux) HandleFunc(pattern string, handler func(context.Context, ResponseWriter, *Msg)) {
 	mux.Handle(pattern, HandlerFunc(handler))
 }
 
@@ -93,16 +94,16 @@ func (mux *ServeMux) HandleRemove(pattern string) {
 //
 // If no handler is found, or there is no question, a standard REFUSED
 // message is returned
-func (mux *ServeMux) ServeDNS(w ResponseWriter, req *Msg) {
+func (mux *ServeMux) ServeDNS(ctx context.Context, w ResponseWriter, req *Msg) {
 	var h Handler
 	if len(req.Question) >= 1 { // allow more than one question
 		h = mux.match(req.Question[0].Name, req.Question[0].Qtype)
 	}
 
 	if h != nil {
-		h.ServeDNS(w, req)
+		h.ServeDNS(ctx, w, req)
 	} else {
-		handleRefused(w, req)
+		handleRefused(ctx, w, req)
 	}
 }
 
@@ -117,6 +118,6 @@ func HandleRemove(pattern string) { DefaultServeMux.HandleRemove(pattern) }
 
 // HandleFunc registers the handler function with the given pattern
 // in the DefaultServeMux.
-func HandleFunc(pattern string, handler func(ResponseWriter, *Msg)) {
+func HandleFunc(pattern string, handler func(context.Context, ResponseWriter, *Msg)) {
 	DefaultServeMux.HandleFunc(pattern, handler)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func HelloServer(w ResponseWriter, req *Msg) {
+func HelloServer(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 
@@ -25,7 +25,7 @@ func HelloServer(w ResponseWriter, req *Msg) {
 	w.WriteMsg(m)
 }
 
-func HelloServerBadID(w ResponseWriter, req *Msg) {
+func HelloServerBadID(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	m.Id++
@@ -35,7 +35,7 @@ func HelloServerBadID(w ResponseWriter, req *Msg) {
 	w.WriteMsg(m)
 }
 
-func HelloServerBadThenGoodID(w ResponseWriter, req *Msg) {
+func HelloServerBadThenGoodID(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	m.Id++
@@ -48,7 +48,7 @@ func HelloServerBadThenGoodID(w ResponseWriter, req *Msg) {
 	w.WriteMsg(m)
 }
 
-func HelloServerEchoAddrPort(w ResponseWriter, req *Msg) {
+func HelloServerEchoAddrPort(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 
@@ -58,7 +58,7 @@ func HelloServerEchoAddrPort(w ResponseWriter, req *Msg) {
 	w.WriteMsg(m)
 }
 
-func AnotherHelloServer(w ResponseWriter, req *Msg) {
+func AnotherHelloServer(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 
@@ -345,8 +345,8 @@ func TestServingTLSConnectionState(t *testing.T) {
 	handlerResponse := "Hello example"
 	// tlsHandlerTLS is a HandlerFunc that can be set to expect or not TLS
 	// connection state.
-	tlsHandlerTLS := func(tlsExpected bool) func(ResponseWriter, *Msg) {
-		return func(w ResponseWriter, req *Msg) {
+	tlsHandlerTLS := func(tlsExpected bool) func(context.Context, ResponseWriter, *Msg) {
+		return func(ctx context.Context, w ResponseWriter, req *Msg) {
 			m := new(Msg)
 			m.SetReply(req)
 			tlsFound := true
@@ -546,7 +546,7 @@ func BenchmarkServe6(b *testing.B) {
 	runtime.GOMAXPROCS(a)
 }
 
-func HelloServerCompress(w ResponseWriter, req *Msg) {
+func HelloServerCompress(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	m.Extra = make([]RR, 1)
@@ -586,7 +586,7 @@ type maxRec struct {
 
 var M = new(maxRec)
 
-func HelloServerLargeResponse(resp ResponseWriter, req *Msg) {
+func HelloServerLargeResponse(ctx context.Context, resp ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	m.Authoritative = true
@@ -710,7 +710,7 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 	defer errOnce.Do(func() {})
 
 	toHandle := int32(requests)
-	HandleFunc("example.com.", func(w ResponseWriter, req *Msg) {
+	HandleFunc("example.com.", func(ctx context.Context, w ResponseWriter, req *Msg) {
 		defer atomic.AddInt32(&toHandle, -1)
 
 		// Wait until ShutdownContext is called before replying.
@@ -871,7 +871,7 @@ func TestHandlerCloseTCP(t *testing.T) {
 
 	hname := "testhandlerclosetcp."
 	triggered := make(chan struct{})
-	HandleFunc(hname, func(w ResponseWriter, r *Msg) {
+	HandleFunc(hname, func(ctx context.Context, w ResponseWriter, r *Msg) {
 		close(triggered)
 		w.Close()
 	})
@@ -1042,7 +1042,7 @@ func TestServerRoundtripTsig(t *testing.T) {
 	defer s.Shutdown()
 
 	handlerFired := make(chan struct{})
-	HandleFunc("example.com.", func(w ResponseWriter, r *Msg) {
+	HandleFunc("example.com.", func(ctx context.Context, w ResponseWriter, r *Msg) {
 		close(handlerFired)
 
 		m := new(Msg)

--- a/xfr_test.go
+++ b/xfr_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -13,7 +14,7 @@ var (
 	xfrTestData = []RR{xfrSoa, xfrA, xfrMX, xfrSoa}
 )
 
-func InvalidXfrServer(w ResponseWriter, req *Msg) {
+func InvalidXfrServer(ctx context.Context, w ResponseWriter, req *Msg) {
 	ch := make(chan *Envelope)
 	tr := new(Transfer)
 
@@ -23,7 +24,7 @@ func InvalidXfrServer(w ResponseWriter, req *Msg) {
 	w.Hijack()
 }
 
-func SingleEnvelopeXfrServer(w ResponseWriter, req *Msg) {
+func SingleEnvelopeXfrServer(ctx context.Context, w ResponseWriter, req *Msg) {
 	ch := make(chan *Envelope)
 	tr := new(Transfer)
 
@@ -33,7 +34,7 @@ func SingleEnvelopeXfrServer(w ResponseWriter, req *Msg) {
 	w.Hijack()
 }
 
-func MultipleEnvelopeXfrServer(w ResponseWriter, req *Msg) {
+func MultipleEnvelopeXfrServer(ctx context.Context, w ResponseWriter, req *Msg) {
 	ch := make(chan *Envelope)
 	tr := new(Transfer)
 


### PR DESCRIPTION
This allows server operators to pass data from the read decorators to the actual DNS handlers.

An example use case where this is needed is when there is any proxying service between eyeball and DNS server. In order
to preserve the client IP, the proxy server might have to use PROXY protocol v2. If you don't have a context you can read and see
the client IPs in the decoraters but your handler will not know this information and therefore might not be able to do things like:

1. Block IPs
2. Verify TSIGs based off specific IP
3. Respond with TSIGs based off source IP
4. Respond with different answers based of IP location

Apart from knowing the source IP, there is other situations where you might want to pass information parsed in the read decorators to the handler.